### PR TITLE
Adding close and fail steps

### DIFF
--- a/data/docs/v2/components/requestBodies/closeStep.json
+++ b/data/docs/v2/components/requestBodies/closeStep.json
@@ -1,0 +1,63 @@
+{
+  "description": "Step to close or fail",
+  "content": {
+    "application/json": {
+      "schema": {
+        "type": "object",
+        "description": "Close step",
+        "required": [
+          "step",
+          "program"
+        ],
+        "properties": {
+          "step": {
+            "$ref": "../../components/schemas/workflow/steps/stepCloseCommon.json#/properties/step"
+          }
+        },
+        "anyOf": [
+          {
+            "$ref": "../../components/schemas/workflow/close/user/confirmAction.json"
+          },
+          {
+            "$ref": "../../components/schemas/workflow/close/user/followPDFInstructions.json"
+          },
+          {
+            "$ref": "../../components/schemas/workflow/close/user/manualDataEntry.json"
+          },
+          {
+            "$ref": "../../components/schemas/workflow/close/machine/aceios.json"
+          }
+        ]
+      }
+    },
+    "application/vnd.fail-step+json": {
+      "schema": {
+        "type": "object",
+        "description": "Fail step",
+        "required": [
+          "step",
+          "program"
+        ],
+        "properties": {
+          "step": {
+            "$ref": "../../components/schemas/workflow/steps/stepCloseCommon.json#/properties/step"
+          }
+        },
+        "anyOf": [
+          {
+            "$ref": "../../components/schemas/workflow/close/user/confirmAction.json"
+          },
+          {
+            "$ref": "../../components/schemas/workflow/close/user/followPDFInstructions.json"
+          },
+          {
+            "$ref": "../../components/schemas/workflow/close/user/manualDataEntry.json"
+          },
+          {
+            "$ref": "../../components/schemas/workflow/close/machine/aceios.json"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/data/docs/v2/components/requestBodies/failStep.json
+++ b/data/docs/v2/components/requestBodies/failStep.json
@@ -1,0 +1,6 @@
+{
+  "description": "Step to fail",
+  "content": {
+
+  }
+}

--- a/data/docs/v2/components/responses/step.json
+++ b/data/docs/v2/components/responses/step.json
@@ -1,0 +1,15 @@
+{
+  "description": "A contact response",
+  "content": {
+    "application/hal+json": {
+      "schema": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "../schemas/hal/halStep.json"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/data/docs/v2/components/schemas/hal/halStep.json
+++ b/data/docs/v2/components/schemas/hal/halStep.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "x-hal": true,
+  "x-ui-hide": true,
+  "properties": {
+    "_links": {
+      "type": "object",
+      "properties": {
+        "self": {
+          "type": "object",
+          "readOnly": true,
+          "properties": {
+            "href": {
+              "type": "string",
+              "example": "https://api.nterprise.com/contexts/5999016c-584c-451a-b007-1ae6bc75bfa6/find-units"
+            }
+          }
+        }
+      }
+    }
+  },
+  "anyOf": [
+    {
+      "$ref": "../workflow/steps/user/manualDataEntry.json"
+    }
+  ]
+}

--- a/data/docs/v2/openapi.json
+++ b/data/docs/v2/openapi.json
@@ -49,6 +49,9 @@
     "/contexts/:context_id": {
       "$ref": "./paths/context.json"
     },
+    "/contexts/:context_id/:step-slug": {
+      "$ref": "./paths/workflow/contextStep.json"
+    },
     "/customers": {
       "$ref": "./paths/customer/customers.json"
     },

--- a/data/docs/v2/paths/operations/context/closeStep.json
+++ b/data/docs/v2/paths/operations/context/closeStep.json
@@ -1,0 +1,25 @@
+{
+  "operationId": "closeStep",
+  "summary": "Closes a step",
+  "description": "This will either complete or fail the step. To fail the step, change the content type when sending the PATCH request",
+  "tags": [
+    "Context"
+  ],
+  "requestBody": {
+    "$ref": "../../../components/requestBodies/closeStep.json"
+  },
+  "responses": {
+    "200": {
+      "$ref": "../../../components/responses/workflow.json"
+    },
+    "400": {
+      "$ref": "../../../components/responses/400badRequest.json"
+    },
+    "401": {
+      "$ref": "../../../components/responses/401unauthorized.json"
+    },
+    "403": {
+      "$ref": "../../../components/responses/403forbidden.json"
+    }
+  }
+}

--- a/data/docs/v2/paths/operations/context/fetchCurrentStepForContext.json
+++ b/data/docs/v2/paths/operations/context/fetchCurrentStepForContext.json
@@ -1,0 +1,24 @@
+{
+  "operationId": "fetchCurrentStepForContext",
+  "summary": "Returns the current step for the context",
+  "description": "Fetch Workflow Contexts",
+  "tags": [
+    "Context"
+  ],
+  "parameters": [
+    {
+      "$ref": "../../../components/parameters/contextId.json"
+    }
+  ],
+  "responses": {
+    "200": {
+      "$ref": "../../../components/responses/step.json"
+    },
+    "401": {
+      "$ref": "../../../components/responses/401unauthorized.json"
+    },
+    "403": {
+      "$ref": "../../../components/responses/403forbidden.json"
+    }
+  }
+}

--- a/data/docs/v2/paths/workflow/contextStep.json
+++ b/data/docs/v2/paths/workflow/contextStep.json
@@ -1,0 +1,8 @@
+{
+  "get": {
+    "$ref": "../operations/context/fetchCurrentStepForContext.json"
+  },
+  "patch": {
+    "$ref": "../operations/context/closeStep.json"
+  }
+}


### PR DESCRIPTION
This adds the missing patch as well as figuring out how to represent the path with just a step slug.

Please note that the example in the docs cannot be built due to using the `anyOf` reference. To understand how to build the request, follow the references in the JSON schema

To close the step you leave the `Content-Type` in the requeset as `application/json`

![Screen Shot 2020-01-15 at 10 38 30](https://user-images.githubusercontent.com/192776/72447362-36ed8280-3783-11ea-8062-117caf0a7f9c.png)

To fail the step, send a `closeStep` payload with just the `step` property set and make sure the `Content-Type` is set to `application/vnd.fail-step+json`

![Screen Shot 2020-01-15 at 10 38 35](https://user-images.githubusercontent.com/192776/72447368-381eaf80-3783-11ea-9b1b-0676dae49c0e.png)
